### PR TITLE
feat(behavior_path_planner): execute avoidance module with avoidance tag

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -55,6 +55,7 @@ public:
   BehaviorModuleOutput plan() override;
   BehaviorModuleOutput planWaitingApproval() override;
   bool isExecutionRequested() const override;
+  bool hasLaneletAvoidanceTag() const;
   bool isExecutionReady() const override;
   void processOnEntry() override;
   void processOnExit() override;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/utils.hpp
@@ -182,6 +182,18 @@ double calcDistanceToAvoidStartLine(
   const lanelet::ConstLanelets & lanelets, const PathWithLaneId & path,
   const std::shared_ptr<const PlannerData> & planner_data,
   const std::shared_ptr<AvoidanceParameters> & parameters);
+
+std::vector<int64_t> getSortedLaneIdsFromPath(const PathWithLaneId & path);
+
+std::vector<int64_t> getSubsequentLaneIdsSetOnPath(const PathWithLaneId & path, int64_t base_lane_id);
+
+boost::optional<int64_t> getNearestLaneId(
+  const PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const geometry_msgs::msg::Pose & current_pose);
+
+std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
+  const PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const geometry_msgs::msg::Pose & current_pose);
 }  // namespace behavior_path_planner::utils::avoidance
 
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__AVOIDANCE__UTILS_HPP_


### PR DESCRIPTION
## Description

With these changes, the avoidance module will only execute if the lane has an `avoidance` tag. 

## Tests performed

<table role="table">
<tbody>
<tr>
<td align="center"><a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/Robicarr-Karsan/autoware.universe.robicarr/assets/32412808/24f009df-3f2f-4c77-a8e2-5dab19173621"><video src="https://github.com/Robicarr-Karsan/autoware.universe.robicarr/assets/32412808/24f009df-3f2f-4c77-a8e2-5dab19173621" width="100%" style="max-width: 100%;"></a></td>
<td align="center"><a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/Robicarr-Karsan/autoware.universe.robicarr/assets/32412808/e48679a0-cd1d-4a72-bda3-f4ba91e081ed"><video src="https://github.com/Robicarr-Karsan/autoware.universe.robicarr/assets/32412808/e48679a0-cd1d-4a72-bda3-f4ba91e081ed" width="100%" style="max-width: 100%;"></a></td>
 </tr>
 </tbody>
 </table>

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
